### PR TITLE
[finishes #162858155]Asker accepts/rejects answer

### DIFF
--- a/app/api/v1/views/question_views.py
+++ b/app/api/v1/views/question_views.py
@@ -169,7 +169,26 @@ def update_and_accept_answer(current_user, question_id, answer_id):
     else:
         return jsonify({"message" : "Can't modify an answer you did not write nor can you accept an answer to a question you did not ask."}), 401
     if ask_ans == 'ask':
-        pass
+        """ Ensure asker only accepts or rejects answer """
+        try:
+            if data["text"] != the_answer["text"]:
+                return jsonify({"Permission denied" : "You can only accept or reject the answer!! nothing else!!"}), 403
+        except:
+            data["text"] = the_answer["text"]
+        try:
+            if data["accepted"] == the_answer["accepted"]:
+                return jsonify({"message" : "user only viewed the answer"}), 200
+        except:
+            data["accepted"] = the_answer["accepted"]
+
+        
+        """ User accepts or rejects answer """
+        if data["accepted"] == "false":
+            return jsonify({"rejection" : "Answer has been rejected"}), 201
+        elif data["accepted"] == "true":
+            return jsonify({"acceptance" : "Answer has been Accepted"}), 201
+        else:
+            return jsonify({"message" : "user only viewed the answer"}), 200
 
     elif ask_ans == 'ans':
         """ Ensure user only updates answer """


### PR DESCRIPTION
### ft-api-user-accept-162858155
### User accepts or rejects answer endpoint

***What The PR Entails***
> An endpoint that enables a user both to update ans answer if asking and accept or reject ans answer if asking
This endpoint is an update on the one for pr #9 

***How to test***
- clone the repo
- install requirements in virtual environment
- use postman 

***Related pt stories***
    #162858155 
***Other Features***
- user validation
- questions validation
- answers validation
- jwt to secure endpoints

![can_only_accept](https://user-images.githubusercontent.com/45054246/50525138-b06bf180-0aea-11e9-8607-fe84486a50b2.png)
![rejected](https://user-images.githubusercontent.com/45054246/50525130-afd35b00-0aea-11e9-8829-d908e19ba876.png)
![answernotfound](https://user-images.githubusercontent.com/45054246/50525131-afd35b00-0aea-11e9-941d-928ed3aa2ae3.png)
![accepted](https://user-images.githubusercontent.com/45054246/50525135-b06bf180-0aea-11e9-9bb8-6e5b1050e550.png)
